### PR TITLE
fix: null tripPoints

### DIFF
--- a/assets/bikes.js
+++ b/assets/bikes.js
@@ -304,7 +304,7 @@ function openRateTripMenu(tripObj) {
                 <br><br>
                 Bicicleta: ${tripObj.bike}
                 <br><br>
-                +${tripObj.tripPoints} <i class="bi bi-arrow-right"></i> ${tripObj.clientPoints} pontos totais
+                +${tripObj.tripPoints ?? 0} <i class="bi bi-arrow-right"></i> ${tripObj.clientPoints} pontos totais
             </div>
             <img src="assets/images/mGira_station.png" alt="station">
             <div id="ratingLabel">Como foi a viagem?</div>


### PR DESCRIPTION
Este PR corrige uma situação rara em que os pontos de uma viagem surgem a null (quando é terminada remotamente pelos técnicos), garantindo que, para valores nullish, a variável passa a 0. Os dados da activeTripSubscription neste caso são algo assim
```json
{
            "activeTripSubscription": {
                "code": "WPXJBT8Z9D",
                "bike": "E1839",
                "startDate": "2023-12-26T12:53:38Z",
                "endDate": "2023-12-26T13:10:53Z",
                "cost": 0,
                "finished": true,
                "canPayWithMoney": false,
                "canUsePoints": false,
                "clientPoints": 58930,
                "tripPoints": null,
                "canceled": false,
                "period": "other",
                "periodTime": "102",
                "error": 0
            }
}
```