### PR TITLE
feat: add detailed statistics menu

### DIFF
--- a/assets/images/caret-down.svg
+++ b/assets/images/caret-down.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#79c000" class="bi bi-caret-down" viewBox="0 0 16 16">
+  <path d="M3.204 5h9.592L8 10.481zm-.753.659 4.796 5.48a1 1 0 0 0 1.506 0l4.796-5.48c.566-.647.106-1.659-.753-1.659H3.204a1 1 0 0 0-.753 1.659"/>
+</svg>

--- a/assets/style.css
+++ b/assets/style.css
@@ -1176,20 +1176,12 @@ input[type="search"]::-webkit-search-results-decoration {
 		0px 0px 5px 0px var(--shadow-green) inset;
 }
 .user-settings #balanceAndBonusContainer #balanceContainer #balanceLabel,
-.user-settings #balanceAndBonusContainer #bonusContainer #bonusLabel,
-.user-settings #statsContainer #totalDistanceContainer #totalDistanceLabel,
-.user-settings #statsContainer #totalTimeContainer #totalTimeLabel,
-.user-settings #statsContainer #co2SavedContainer #co2SavedLabel,
-.user-settings #statsContainer #numberOfTripsContainer #numberOfTripsLabel {
+.user-settings #balanceAndBonusContainer #bonusContainer #bonusLabel {
 	position: absolute;
 	top: 8%;
 }
 .user-settings #balanceAndBonusContainer #balanceContainer #balance,
-.user-settings #balanceAndBonusContainer #bonusContainer #bonus,
-.user-settings #statsContainer #totalDistanceContainer #totalDistance,
-.user-settings #statsContainer #totalTimeContainer #totalTime,
-.user-settings #statsContainer #co2SavedContainer #co2Saved,
-.user-settings #statsContainer #numberOfTripsContainer #numberOfTrips {
+.user-settings #balanceAndBonusContainer #bonusContainer #bonus {
 	position: absolute;
 	bottom: 20%;
 	font-size: 1.5rem;
@@ -1238,35 +1230,7 @@ input[type="search"]::-webkit-search-results-decoration {
 	text-wrap: pretty;
 	font-size: 1.2rem;
 }
-.user-settings #statsContainer {
-	width: 100vw;
-	height: 27vh;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	flex-direction: row;
-	flex-wrap: wrap;
-	row-gap: 3vh;
-	column-gap: 2vh;
-	margin-top: 3vh;
-}
-.user-settings #statsContainer #totalDistanceContainer,
-.user-settings #statsContainer #totalTimeContainer,
-.user-settings #statsContainer #co2SavedContainer,
-.user-settings #statsContainer #numberOfTripsContainer {
-	width: 42.5%;
-	height: 44.4%;
-	color: var(--green);
-	border-radius: 25px;
-	display: flex;
-	justify-content: center;
-	flex-basis: 42.5%;
-	position: relative;
-	outline: 1px solid var(--green);
-	box-shadow:
-		0px 4px 6px 0px var(--shadow-green),
-		0px 0px 5px 0px var(--shadow-green) inset;
-}
+.user-settings #statisticsMenuButtonContainer,
 .user-settings #tripHistoryButtonContainer {
 	width: 100vw;
 	display: flex;
@@ -1274,13 +1238,20 @@ input[type="search"]::-webkit-search-results-decoration {
 	justify-content: center;
 	margin-top: 3vh;
 }
+.user-settings #statisticsMenuButton,
 .user-settings #tripHistoryButton {
-	width: calc(85vw + 2vh - 5vh);
-	padding: 2.5vh;
+	width: calc(85vw + 2vh - 5dvh);
+	padding: 2dvh 3dvh;
 	background-color: var(--green);
 	border-radius: 999px;
 	color: var(--white);
-	text-align: center;
+	display: flex;
+	align-items: center;
+	gap: 1dvh
+}
+.user-settings #statisticsMenuButton i,
+.user-settings #tripHistoryButton i {
+	font-size: 1.5rem;
 }
 .user-settings #settingsContainer {
 	width: 100vw;
@@ -2045,5 +2016,128 @@ input[type="search"]::-webkit-search-results-decoration {
 	font-size: 0.7rem;
   	width: 80%;
 	text-align: right;
+}
+/* #endregion */
+
+/* #region Statistics menu */
+#statisticsMenu {
+	background-color: var(--black);
+	width: 100%;
+	height: 100%;
+	position: absolute;
+	z-index: 4;
+	left: 0;
+	top: 0;
+	border-radius: 0;
+	/*animation: smooth-slide-from-bottom 1s ease forwards;*/
+}
+#statisticsMenu #graphics {
+	height: 25vw;
+	width: 100%;
+	object-fit: cover;
+	rotate: 180deg;
+	opacity: 2%;
+}
+#statisticsMenu #backButton {
+	position: absolute;
+	top: 2.5dvh;
+	left: 5%;
+	font-size: calc(0.35 * 7dvh);
+	margin-bottom: 1dvh;
+	border-radius: 999px;
+	color: var(--green);
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+#statisticsMenu #backButton i {
+	width: 32px;
+	height: 32px;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+}
+#statisticsMenu #title {
+	position: absolute;
+	top: 2.5dvh;
+	right: 5%;
+	font-size: 1.3rem;
+	font-weight: bold;
+	color: var(--green);
+}
+#statisticsMenu #usableArea {
+	position: absolute;
+	top: 8dvh;
+	left: 0;
+	width: 100vw;
+	height: 92dvh;
+	display: flex;
+	flex-direction: column;
+	gap: 2dvh;
+}
+#statisticsMenu .chart-container {
+	position: relative;
+	width: 100vw;
+	flex-grow: 1;
+}
+#statisticsMenu #statsControls {
+	width: 100vw;
+	height: fit-content;
+	background-color: var(--white);
+	border-radius: 30px 30px 0 0;
+	padding-bottom: 4dvh;
+}
+#statisticsMenu #statsControls select {
+	appearance: none;
+	-webkit-appearance: none;
+	width: 90%;
+	margin-left: 5%;
+	font-size: 1rem;
+	padding: 0.675em 6em 0.675em 1em;
+	background-color: var(--white);
+	border: 1px solid var(--green);
+	border-radius: 999px;
+	color: var(--green);
+	cursor: pointer;
+	background-image: url("images/caret-down.svg");
+	background-repeat: no-repeat;
+	background-position-x: calc(100% - 10px);
+	background-position-y: calc(100% - 14px);
+}
+#statisticsMenu #statsControls .stats-control-label {
+	width: 90%;
+	margin-left: calc(5% + 1em);
+	font-size: 0.9rem;
+	color: var(--green);
+	margin-top: 3dvh;
+}
+#statisticsMenu #statsTotals {
+	width: 100vw;
+	height: calc(6dvh + 1rem);
+	display: flex;
+	gap: 1dvh;
+  	justify-content: center;
+}
+#statisticsMenu #statsTotals .stats-totals-element {
+	width: 30vw;
+	height: calc(6dvh + 1rem);
+}
+#statisticsMenu #statsTotals .stats-totals-element div:first-child {
+	width: 100%;
+	height: 6dvh;
+	border-radius: 999px;
+	background-color: var(--green);
+	color: var(--white);
+	font-size: 1rem;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+#statisticsMenu #statsTotals .stats-totals-element div:nth-child(2) {
+	width: 100%;
+	height: 1rem;
+	color: var(--green);
+	font-size: 0.75rem;
+	text-align: center;
 }
 /* #endregion */

--- a/index.html
+++ b/index.html
@@ -50,6 +50,7 @@
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ol@v8.1.0/ol.css" />
 		<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" />
 
+		<!-- JS imports -->
 		<script src="scripts/bikeSerialNumberMapping.js"></script>
 		<script src="scripts/tokenRefresh.js"></script>
 		<script src="scripts/requests.js"></script>
@@ -67,6 +68,8 @@
 		<script src="https://cdn.jsdelivr.net/npm/ol@v8.1.0/dist/ol.js"></script>
 		<script src="https://unpkg.com/ol-mapbox-style@9.4.0/dist/olms.js"></script>
 		<script type="module" src="https://unpkg.com/openrouteservice-js@0.3.2/dist/ors-js-client.js"></script>
+		<script src=" https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js "></script>
+
 	</head>
 	<body onload="initMap();">
 		<!-- Map -->
@@ -156,7 +159,7 @@
 				return (
 					(ele && ele.tagName === "INPUT") ||
 					ele.tagName === "TEXTAREA" ||
-					ele.getAttribute("contenteditable").toString() === "true"
+					ele.getAttribute("contenteditable") ? ele.getAttribute("contenteditable").toString() === "true": false
 				);
 			}
 

--- a/index.html
+++ b/index.html
@@ -174,18 +174,30 @@
 			// Prevent system back button exiting the app
 			window.addEventListener("load", () => window.history.pushState({}, ""));
 
+			// Handle system back button
 			window.addEventListener("popstate", () => {
 				// Back button was pressed
 				window.history.pushState({}, "");
 
-				// Hide user menu if it is showing
-				hideUserSettings();
+				// Get elements
+				let stationMenu = document.getElementById("stationMenu");
+				let bikeListMenu = document.getElementById("bikeMenu");
+				let tripHistoryMenu = document.getElementById("tripHistory");
+				let statisticsMenu = document.getElementById("statisticsMenu");
 
 				// Hide search place menu if it is showing
 				hidePlaceSearchMenu();
 
+				// Hide user menu
+				if (!tripHistoryMenu && !statisticsMenu) hideUserSettings();
+
+				// Hide trip history menu
+				if (tripHistoryMenu) hideTripHistory();
+
+				// Hide statistics menu
+				if (statisticsMenu) hideStatisticsMenu();
+
 				// Hide bike list menu if it is showing
-				let bikeListMenu = document.getElementById("bikeMenu");
 				if (bikeListMenu) {
 					bikeListMenu.classList.add("smooth-slide-to-bottom");
 					setTimeout(() => bikeListMenu.remove(), 500); // remove element after animation
@@ -193,10 +205,9 @@
 				}
 
 				// Hide station card if it is showing
-				let menu = document.getElementById("stationMenu");
-				if (menu) {
-					menu.classList.add("smooth-slide-to-left");
-					setTimeout(() => menu.remove(), 500); // remove element after animation
+				if (stationMenu) {
+					stationMenu.classList.add("smooth-slide-to-left");
+					setTimeout(() => stationMenu.remove(), 500); // remove element after animation
 					document.getElementById("zoomControls").classList.add("smooth-slide-down-zoom-controls"); // move zoom controls back down
 				}
 			});

--- a/scripts/extras.js
+++ b/scripts/extras.js
@@ -49,3 +49,30 @@ function getCookie(cname) {
     }
     return "";
 }
+
+
+function parseMillisecondsIntoReadableTime(milliseconds){
+
+	// Get days from milliseconds
+	var days = milliseconds / (24*1000*60*60);
+	var absoluteDays = Math.floor(days);
+	var d = absoluteDays;
+
+	// Get remainder from days and convert to hours 
+	var hours = (days - absoluteDays) * 24;
+	var absoluteHours = Math.floor(hours);
+	var h = absoluteHours > 9 ? absoluteHours : '0' + absoluteHours;
+  
+	//Get remainder from hours and convert to minutes
+	var minutes = (hours - absoluteHours) * 60;
+	var absoluteMinutes = Math.floor(minutes);
+	var m = absoluteMinutes > 9 ? absoluteMinutes : '0' +  absoluteMinutes;  
+  
+	// Return in 0d00h00m format
+	if (d > 0)
+		return d + 'd' + h + 'h' + m + 'm';
+	else if (h > 0)
+		return h + 'h' + m + 'm'
+	else 
+		return m + 'm'
+  }

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -73,7 +73,6 @@ async function getUserInformation() {
 
 // Open the login menu element and populate it
 function openLoginMenu() {
-
 	document.cookie = "version=0.0.0"; // Force show update notes after logout
 	document.cookie = 'refreshToken=None;path="/";expires=Thu, 01 Jan 1970 00:00:01 GMT'; // delete cookie
 
@@ -106,7 +105,6 @@ function openLoginMenu() {
 	if (document.querySelectorAll(".login-menu").length === 0) document.body.appendChild(menu);
 }
 
-
 // Open user settings element and populate it
 async function openUserSettings() {
 	// show the container from the start so that the request delay is less noticeable
@@ -126,14 +124,13 @@ async function openUserSettings() {
 	let userObj = user; // get from global variable
 
 	// Get all the user information, if it isn't available yet
-	if (!userObj.activeUserSubscriptions)
-		userObj = await getUserInformation();
+	if (!userObj.activeUserSubscriptions) userObj = await getUserInformation();
 
 	// Get subscription expiration
 	const subscriptionExpiration = new Date(userObj.activeUserSubscriptions[0].expirationDate);
 
 	// Get user initials
-	let allNames = userObj.name.split(" ");  // separate all names
+	let allNames = userObj.name.split(" "); // separate all names
 	let initials = allNames[0][0] + allNames.at(-1)[0]; // first letter of first name + first letter of last name
 
 	// Populate the element
@@ -240,14 +237,12 @@ function openSetProxyPrompt() {
 	);
 }
 
-
 function setUserImageInitials(username) {
-
 	// Set the initials of the user name to act like picture
 	// (removes dependency on ui-avatars.com)
 
 	// Get the initials
-	let allNames = username.split(" ");  // separate all names
+	let allNames = username.split(" "); // separate all names
 	let initials = allNames[0][0] + allNames.at(-1)[0]; // first letter of first name + first letter of last name
 
 	// User picture (main screen)
@@ -255,9 +250,7 @@ function setUserImageInitials(username) {
 	userInitialsElement.innerHTML = initials;
 }
 
-
 function openTripHistory() {
-
 	// Create element
 	let menu = document.createElement("div");
 	menu.id = "tripHistory";
@@ -284,20 +277,22 @@ function openTripHistory() {
 		// Get formatted date
 		let tripDate = new Date(trip.startDate);
 		let monthNumberToShortForm = [
-			'jan.',
-			'fev.',
-			'mar.',
-			'abr.',
-			'mai.',
-			'jun.',
-			'jul.',
-			'ago.',
-			'set.',
-			'out.',
-			'nov.',
-			'dez.'
+			"jan.",
+			"fev.",
+			"mar.",
+			"abr.",
+			"mai.",
+			"jun.",
+			"jul.",
+			"ago.",
+			"set.",
+			"out.",
+			"nov.",
+			"dez.",
 		];
-		const formattedDate = `${tripDate.getDay()} ${monthNumberToShortForm[tripDate.getMonth()]} ${tripDate.getFullYear()}`;
+		const formattedDate = `${tripDate.getDay()} ${
+			monthNumberToShortForm[tripDate.getMonth()]
+		} ${tripDate.getFullYear()}`;
 
 		// Get formatted time
 		let tripTime = new Date(new Date(trip.endDate) - new Date(trip.startDate));
@@ -349,17 +344,15 @@ function openTripHistory() {
 
 function hideTripHistory() {
 	// Remove element from DOM
-	document.getElementById('tripHistory').remove();
+	document.getElementById("tripHistory").remove();
 
 	// Show user settings again
 	let userSettingsElem = document.getElementById("userSettings");
 	userSettingsElem.style.maxHeight = "";
 }
 
-
 // Statistics Menu
 function openStatisticsMenu() {
-	
 	// Create element
 	let menu = document.createElement("div");
 	menu.id = "statisticsMenu";
@@ -427,7 +420,7 @@ function openStatisticsMenu() {
 
 function hideStatisticsMenu() {
 	// Remove element from DOM
-	document.getElementById('statisticsMenu').remove();
+	document.getElementById("statisticsMenu").remove();
 
 	// Show user settings again
 	let userSettingsElem = document.getElementById("userSettings");
@@ -435,7 +428,6 @@ function hideStatisticsMenu() {
 }
 
 function updateStatisticsChart() {
-
 	// Get the selected options
 	let period = document.getElementById("periodControl").value;
 	let groupBy = document.getElementById("groupControl").value;
@@ -445,58 +437,50 @@ function updateStatisticsChart() {
 
 	if (period === "last7days") {
 		numberOfDays = 7;
-	}
-	else if (period === "last30days") {
+	} else if (period === "last30days") {
 		numberOfDays = 30;
-	}
-	else if (period === "lastYear") 
-		numberOfDays = 365;
+	} else if (period === "lastYear") numberOfDays = 365;
 	else if (period === "total") {
 		// Start from the day the user account was activated
-		let timeFromActivated = Date.now() - (new Date(user.dateActivate).getTime());
+		let timeFromActivated = Date.now() - new Date(user.dateActivate).getTime();
 
 		// Convert the milliseconds to days
-		var days = timeFromActivated / (24*1000*60*60);
+		var days = timeFromActivated / (24 * 1000 * 60 * 60);
 		var absoluteDays = Math.floor(days);
 
 		numberOfDays = absoluteDays;
 	}
 
-	console.log(numberOfDays);
-
-
 	let startDate = new Date(new Date().setDate(new Date().getDate() - (numberOfDays - 1)));
 
 	let tripsInPeriod = {
-		"total": {
-			"number_of_trips": 0,
-			"time_ridden": 0,
-			"distance": 0
-		}
+		total: {
+			number_of_trips: 0,
+			time_ridden: 0,
+			distance: 0,
+		},
 	};
 
 	// Create object linking each group with the trips
 	for (let days = 0; days < numberOfDays; days++) {
-
 		const start = startDate;
 
 		// Add days to start date
-		const dayDate = new Date(start.getFullYear(),start.getMonth(),start.getDate() + days);
+		const dayDate = new Date(start.getFullYear(), start.getMonth(), start.getDate() + days);
 
 		// If seeing total period, include also the year (to not repeat objects...)
-		const dayMonthString = 
-			period === "total" ? 
-			`${dayDate.getDate()}/${(dayDate.getMonth() + 1)}/${dayDate.getFullYear().toString().substring(2)}` : // only last 2 digits of year
-			`${dayDate.getDate()}/${(dayDate.getMonth() + 1)}`;
+		const dayMonthString =
+			period === "total"
+				? `${dayDate.getDate()}/${dayDate.getMonth() + 1}/${dayDate.getFullYear().toString().substring(2)}` // only last 2 digits of year
+				: `${dayDate.getDate()}/${dayDate.getMonth() + 1}`;
 
 		// Get the trips of the day
-		const dayTrips = user.tripHistory.filter((trip) => (
-			(new Date(trip.startDate)).getDate() === dayDate.getDate() // Same day
-			&&
-			(new Date(trip.startDate)).getMonth() === dayDate.getMonth() // Same month
-			&&
-			(new Date(trip.startDate)).getFullYear() === dayDate.getFullYear() // Same year
-		));
+		const dayTrips = user.tripHistory.filter(
+			trip =>
+				new Date(trip.startDate).getDate() === dayDate.getDate() && // Same day
+				new Date(trip.startDate).getMonth() === dayDate.getMonth() && // Same month
+				new Date(trip.startDate).getFullYear() === dayDate.getFullYear() // Same year
+		);
 
 		// Get the time (in ms) and distance (in km) ridden for each trip
 		for (trip of dayTrips) {
@@ -504,50 +488,48 @@ function updateStatisticsChart() {
 			trip.riddenTime = tripTime.getTime();
 			// Calculate an estimate for trip distance (assuming an avg speed of 15km/h)
 			const speed = 15 / (3600 * 1000); // convert km/h to km/ms
-			trip.distance = Math.round((tripTime.getTime() * speed) * 1000) / 1000; // milliseconds * km in 1 millisecond (and round to 3 decimal places)
+			trip.distance = Math.round(tripTime.getTime() * speed * 1000) / 1000; // milliseconds * km in 1 millisecond (and round to 3 decimal places)
 		}
 
 		// Create the new object
 		tripsInPeriod[dayMonthString] = {
-			"number_of_trips": dayTrips.length,
-			"time_ridden": dayTrips.length === 0 ? 0 : dayTrips.reduce((total_time, trip) => total_time + trip.riddenTime, 0),
-			"distance": dayTrips.length === 0 ? 0 : dayTrips.reduce((total_distance, trip) => total_distance + trip.distance, 0)
-		}
+			number_of_trips: dayTrips.length,
+			time_ridden: dayTrips.length === 0 ? 0 : dayTrips.reduce((total_time, trip) => total_time + trip.riddenTime, 0),
+			distance:
+				dayTrips.length === 0 ? 0 : dayTrips.reduce((total_distance, trip) => total_distance + trip.distance, 0),
+		};
 
 		// Add to the total object
 		tripsInPeriod.total.number_of_trips += dayTrips.length;
-		tripsInPeriod.total.time_ridden += dayTrips.length === 0 ? 0 : dayTrips.reduce((total_time, trip) => total_time + trip.riddenTime, 0);
-		tripsInPeriod.total.distance += dayTrips.length === 0 ? 0 : dayTrips.reduce((total_distance, trip) => total_distance + trip.distance, 0);
+		tripsInPeriod.total.time_ridden +=
+			dayTrips.length === 0 ? 0 : dayTrips.reduce((total_time, trip) => total_time + trip.riddenTime, 0);
+		tripsInPeriod.total.distance +=
+			dayTrips.length === 0 ? 0 : dayTrips.reduce((total_distance, trip) => total_distance + trip.distance, 0);
 	}
 
 	let groupedTripsInPeriod = {
-		"total": {
-			"number_of_trips": tripsInPeriod.total.number_of_trips,
-			"time_ridden": tripsInPeriod.total.time_ridden,
-			"distance": tripsInPeriod.total.distance
-		}
+		total: {
+			number_of_trips: tripsInPeriod.total.number_of_trips,
+			time_ridden: tripsInPeriod.total.time_ridden,
+			distance: tripsInPeriod.total.distance,
+		},
 	};
 
 	// Group the trips by period
 	if (groupBy === "days") {
-		
 		groupedTripsInPeriod = tripsInPeriod;
-
-	}
-	else if (groupBy === "weeks") {
-
+	} else if (groupBy === "weeks") {
 		const daysInWeek = 7;
 
 		const entries = Object.entries(tripsInPeriod);
 
-		for (let index = 1; index < (entries.length - 1); index += daysInWeek) {
-
-			let slicedTripsInPeriod = entries.slice(index, index + daysInWeek)
+		for (let index = 1; index < entries.length - 1; index += daysInWeek) {
+			let slicedTripsInPeriod = entries.slice(index, index + daysInWeek);
 			let keyName = `${slicedTripsInPeriod.at(0)[0]}-${slicedTripsInPeriod.at(-1)[0]}`;
 			groupedTripsInPeriod[keyName] = {
-				"number_of_trips": 0,
-				"time_ridden": 0,
-				"distance": 0
+				number_of_trips: 0,
+				time_ridden: 0,
+				distance: 0,
 			};
 
 			// group all the data
@@ -557,21 +539,17 @@ function updateStatisticsChart() {
 				groupedTripsInPeriod[keyName]["distance"] += dayData.distance;
 			}
 		}
-
-	}
-	else if (groupBy === "months") {
-
+	} else if (groupBy === "months") {
 		const daysInMonth = 30;
 		const entries = Object.entries(tripsInPeriod);
 
-		for (let index = 1; index < (entries.length - 1); index += daysInMonth) {
-
-			let slicedTripsInPeriod = entries.slice(index, index + daysInMonth)
+		for (let index = 1; index < entries.length - 1; index += daysInMonth) {
+			let slicedTripsInPeriod = entries.slice(index, index + daysInMonth);
 			let keyName = `${slicedTripsInPeriod.at(0)[0]}-${slicedTripsInPeriod.at(-1)[0]}`;
 			groupedTripsInPeriod[keyName] = {
-				"number_of_trips": 0,
-				"time_ridden": 0,
-				"distance": 0
+				number_of_trips: 0,
+				time_ridden: 0,
+				distance: 0,
 			};
 
 			// group all the data
@@ -581,10 +559,7 @@ function updateStatisticsChart() {
 				groupedTripsInPeriod[keyName]["distance"] += dayData.distance;
 			}
 		}
-
 	}
-
-	console.log(groupedTripsInPeriod);
 
 	// Get labels and data (use slice to ignore total)
 	let labels = Object.keys(groupedTripsInPeriod).slice(1);
@@ -592,23 +567,28 @@ function updateStatisticsChart() {
 	let data;
 	let yAxisLabel;
 	if (statistic === "timeRidden") {
-		data = Object.values(groupedTripsInPeriod).slice(1).map((period) => Math.floor(period.time_ridden / 60000)); // convert to minutes
-		dataLabel = 'Tempo em viagem (min)';
-		yAxisLabel = 'Minutos';
-	}
-	else if (statistic === "distance") {
-		data = Object.values(groupedTripsInPeriod).slice(1).map((period) => period.distance);
-		dataLabel = 'Distância (km)';
-		yAxisLabel = 'Quilómetros';
+		data = Object.values(groupedTripsInPeriod)
+			.slice(1)
+			.map(period => Math.floor(period.time_ridden / 60000)); // convert to minutes
+		dataLabel = "Tempo em viagem (min)";
+		yAxisLabel = "Minutos";
+	} else if (statistic === "distance") {
+		data = Object.values(groupedTripsInPeriod)
+			.slice(1)
+			.map(period => period.distance);
+		dataLabel = "Distância (km)";
+		yAxisLabel = "Quilómetros";
 	}
 
 	// Set totals in HTML
-	document.querySelector('#statsTotals #time').innerHTML = parseMillisecondsIntoReadableTime(groupedTripsInPeriod.total.time_ridden);
-	document.querySelector('#statsTotals #distance').innerHTML = Math.round(groupedTripsInPeriod.total.distance) + "km";
-	document.querySelector('#statsTotals #trips').innerHTML = groupedTripsInPeriod.total.number_of_trips;
+	document.querySelector("#statsTotals #time").innerHTML = parseMillisecondsIntoReadableTime(
+		groupedTripsInPeriod.total.time_ridden
+	);
+	document.querySelector("#statsTotals #distance").innerHTML = Math.round(groupedTripsInPeriod.total.distance) + "km";
+	document.querySelector("#statsTotals #trips").innerHTML = groupedTripsInPeriod.total.number_of_trips;
 
 	// Change chart font color
-	Chart.defaults.color = '#d9d9da';
+	Chart.defaults.color = "#d9d9da";
 
 	// Destroy previous chart if it exists
 	let oldChart = Chart.getChart("statsChart");
@@ -617,45 +597,47 @@ function updateStatisticsChart() {
 	}
 
 	// Create new chart
-	const chartElem = document.getElementById('statsChart');
+	const chartElem = document.getElementById("statsChart");
 	new Chart(chartElem, {
-	  type: 'bar',
-	  data: {
-		labels: labels,
-		datasets: [{
-		  label: dataLabel,
-		  data: data,  
-		  borderWidth: 1,
-		  borderRadius: 10,
-		  backgroundColor: '#79c00080',
-		  borderColor: '#79c000',
-		}]
-	  },
-	  options: {
-		scales: {
-			x: {
-				display: false,
+		type: "bar",
+		data: {
+			labels: labels,
+			datasets: [
+				{
+					label: dataLabel,
+					data: data,
+					borderWidth: 1,
+					borderRadius: 10,
+					backgroundColor: "#79c00080",
+					borderColor: "#79c000",
+				},
+			],
+		},
+		options: {
+			scales: {
+				x: {
+					display: false,
+				},
+				y: {
+					beginAtZero: true,
+					title: {
+						display: true,
+						text: yAxisLabel,
+					},
+				},
 			},
-			y: {
-				beginAtZero: true,
-				title: {
-					display: true,
-					text: yAxisLabel
-				}
-			}
+			layout: {
+				padding: {
+					left: 5,
+					right: 20,
+				},
+			},
+			plugins: {
+				legend: {
+					display: false,
+				},
+			},
+			maintainAspectRatio: false,
 		},
-		layout: {
-			padding: {
-				left: 5,
-				right: 20
-			}
-		},
-		plugins: {
-            legend: {
-                display: false
-            },
-        },
-		maintainAspectRatio: false,
-	  }
 	});
 }

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -534,9 +534,9 @@ function updateStatisticsChart() {
 
 			// group all the data
 			for (const [day, dayData] of slicedTripsInPeriod) {
-				groupedTripsInPeriod[keyName]["number_of_trips"] += dayData.number_of_trips;
-				groupedTripsInPeriod[keyName]["time_ridden"] += dayData.time_ridden;
-				groupedTripsInPeriod[keyName]["distance"] += dayData.distance;
+				groupedTripsInPeriod[keyName].number_of_trips += dayData.number_of_trips;
+				groupedTripsInPeriod[keyName].time_ridden += dayData.time_ridden;
+				groupedTripsInPeriod[keyName].distance += dayData.distance;
 			}
 		}
 	} else if (groupBy === "months") {


### PR DESCRIPTION
Este PR:
- adiciona um novo menu de estatísticas detalhadas
- remove o antigo painel de estatísticas no perfil
- atualiza a UI dos botões do perfil

O utilizador pode escolher qual o período, como agrupar os dados e qual a estatística que deseja ver.

Serão necessários alguns testes para ter a certeza que se encontra estável e fazer também algumas melhorias com o vosso feedback.