### PR TITLE
fix: better token refresh, removed forgotten console logs

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
 				proxyURL = decodeURI(tempCustomProxy);
 			} else {
 				console.log("Using default proxy");
-				proxyURL = "https://corsproxy.afonsosousah.workers.dev/";
+				proxyURL = null;
 			}
 
 			// Prevent resize on keyboard open

--- a/index.html
+++ b/index.html
@@ -117,6 +117,11 @@
 				}
 			});
 
+			// Request persistent storage for site
+			if (navigator.storage && navigator.storage.persist) {
+				navigator.storage.persist().then(isPersisted => console.log(`Persisted storage granted: ${isPersisted}`));
+			}
+
 			// Check if the user has set customProxy. if not, use default proxy
 			const tempCustomProxy = getCookie("customProxy");
 			if (tempCustomProxy) {
@@ -124,15 +129,7 @@
 				proxyURL = decodeURI(tempCustomProxy);
 			} else {
 				console.log("Using default proxy");
-			}
-
-			// Check if the user is logged in, if not, prompt to login
-			const tempTokenRefresh = getCookie("refreshToken");
-			if (tempTokenRefresh) {
-				user.refreshToken = tempTokenRefresh;
-				//tokenRefresh();
-			} else {
-				openLoginMenu();
+				proxyURL = "https://corsproxy.afonsosousah.workers.dev/";
 			}
 
 			// Prevent resize on keyboard open

--- a/proxy.php
+++ b/proxy.php
@@ -45,9 +45,9 @@ define('CSAJAX_DEBUG', true);
  * A set of valid cross domain requests
  */
 $valid_requests = array(
-  'api-auth.emel.pt',
-  'apigira.emel.pt',
-  'opendata.emel.pt'
+    'api-auth.emel.pt',
+    'apigira.emel.pt',
+    'opendata.emel.pt'
 );
 
 /**
@@ -64,17 +64,19 @@ $curl_options = array(
 /* * * STOP EDITING HERE UNLESS YOU KNOW WHAT YOU ARE DOING * * */
 
 // identify request headers
-$request_headers = array( );
+$request_headers = array();
 foreach ($_SERVER as $key => $value) {
     if (strpos($key, 'HTTP_') === 0  ||  strpos($key, 'CONTENT_') === 0) {
         $headername = str_replace('_', ' ', str_replace('HTTP_', '', $key));
         $headername = str_replace(' ', '-', ucwords(strtolower($headername)));
-        if (!in_array($headername, array( 'Host', 'X-Proxy-Url', 'X-Authorization' ))) {
-          $request_headers[] = "$headername: $value";
-        }
-        else if($headername == 'X-Authorization') {
-          $request_headers[] = "Authorization: $value";
-          //csajax_debug_message("Authorization header modified correctly!");
+        if (
+            !in_array($headername, array('Host', 'X-Proxy-Url', 'X-Authorization'))
+            && in_array($headername, array('Content-Type', 'Content-Length'))
+        ) {
+            $request_headers[] = "$headername: $value";
+        } else if ($headername == 'X-Authorization') {
+            $request_headers[] = "Authorization: $value";
+            //csajax_debug_message("Authorization header modified correctly!");
         }
     }
 }
@@ -153,7 +155,7 @@ $ch = curl_init($request_url);
 
 // Suppress Expect header
 if (CSAJAX_SUPPRESS_EXPECT) {
-    array_push($request_headers, 'Expect:'); 
+    array_push($request_headers, 'Expect:');
 }
 
 curl_setopt($ch, CURLOPT_HTTPHEADER, $request_headers);   // (re-)send headers

--- a/scripts/bikes.js
+++ b/scripts/bikes.js
@@ -363,6 +363,9 @@ async function tripTimer(startTime) {
 		}
 		tripTimerRunning = true;
 		setTimeout(() => tripTimer(startTime), 1000);
+	} else if (ws?.readyState !== WebSocket.OPEN) {
+		console.log("WebSocket has disconnected...");
+		setTimeout(() => tripTimer(startTime), 1000);
 	} else {
 		console.log("Trip has ended...");
 		tripTimerRunning = false;

--- a/scripts/bikes.js
+++ b/scripts/bikes.js
@@ -2,6 +2,7 @@ let tripEnded = true;
 let tripTimerRunning = false;
 let ratedTripsList = [];
 let finishedTripsList = [];
+let tripBeingRated = false;
 
 // reserves the bike and returns a success boolean
 async function reserveBike(serialNumber) {
@@ -385,6 +386,9 @@ function openRateTripMenu(tripObj) {
 	// Don't rate trips under 90 seconds
 	if (elapsedTime < 90 * 1000) return;
 
+	// Set that there is a trip being rated (don't show any new ratings while this is true)
+	tripBeingRated = true;
+
 	// Show the rate trip menu
 	appendElementToBodyFromHTML(`
     <div class="rate-trip-menu" id="rateTripMenu">
@@ -459,6 +463,7 @@ async function rateTrip(tripCode, tripCost) {
 		if (document.getElementById("rateTripMenu")) document.getElementById("rateTripMenu").remove();
 	} else {
 		alert("Não foi possível obter a classificação.");
+		tripBeingRated = false;
 		return;
 	}
 
@@ -482,6 +487,7 @@ async function rateTrip(tripCode, tripCost) {
 				} else {
 					alert("Não foi possível avaliar a viagem.");
 				}
+				tripBeingRated = false;
 			},
 			async () => {
 				// No handler
@@ -498,6 +504,7 @@ async function rateTrip(tripCode, tripCost) {
 				} else {
 					alert("Não foi possível avaliar a viagem.");
 				}
+				tripBeingRated = false;
 			}
 		);
 	} else {
@@ -514,6 +521,7 @@ async function rateTrip(tripCode, tripCost) {
 		} else {
 			alert("Não foi possível avaliar a viagem.");
 		}
+		tripBeingRated = false;
 	}
 }
 

--- a/scripts/extras.js
+++ b/scripts/extras.js
@@ -94,7 +94,6 @@ function parseMillisecondsIntoTripTime(milliseconds, showSeconds = true) {
 	return (absoluteHours > 0 ? h + "h" : "") + m + "m" + (showSeconds ? s + "s" : "");
 }
 
-
 function changeThemeColor(color) {
 	metaThemeColor = document.querySelector("meta[name=theme-color]").setAttribute("content", color);
 }

--- a/scripts/extras.js
+++ b/scripts/extras.js
@@ -107,3 +107,45 @@ function downloadObjectAsJson(exportObj, exportName) {
 	downloadAnchorNode.click();
 	downloadAnchorNode.remove();
 }
+
+function getTLD() {
+	let hostname;
+	let url = window.location.href;
+
+	//find & remove protocol (http, ftp, etc.) and get hostname
+	if (url.indexOf("://") > -1) {
+		hostname = url.split("/")[2];
+	} else {
+		hostname = url.split("/")[0];
+	}
+
+	//find & remove port number
+	hostname = hostname.split(":")[0];
+
+	//find & remove "?"
+	hostname = hostname.split("?")[0];
+
+	// Get TLD
+	let hostnames = hostname.split(".");
+	hostname =
+		hostnames.length === 1 ? hostname : hostnames[hostnames.length - 2] + "." + hostnames[hostnames.length - 1];
+
+	return hostname;
+}
+
+function createCookie(name, value, expiryDate) {
+	document.cookie =
+		name +
+		"=" +
+		value +
+		"; expires=" +
+		expiryDate.toGMTString() +
+		"; SameSite=strict" +
+		"; Domain=" +
+		getTLD() +
+		"; Path=/;";
+}
+
+function deleteCookie(name) {
+	document.cookie = name + "=; expires=Thu, 01 Jan 1970 00:00:01 GMT; Path=/; SameSite=strict";
+}

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -67,6 +67,32 @@ async function initMap() {
 			viewRoute(ol.proj.transform(feature.getGeometry().getCoordinates(), "EPSG:3857", "EPSG:4326"));
 	});
 
+	/* Run the startup functions */
+
+	// Check if the user is logged in, if not, prompt to login
+	const refreshTokenCookie = getCookie("refreshToken");
+	if (refreshTokenCookie) {
+		user.refreshToken = refreshTokenCookie;
+	} else {
+		openLoginMenu();
+		return;
+	}
+
+	// Check if the user is logged in, if not, prompt to login
+	const accessTokenCookie = getCookie("accessToken");
+	if (accessTokenCookie) {
+		user.accessToken = accessTokenCookie;
+	}
+
+	// Start WebSocket connection
+	startWSConnection();
+
+	// Get all user details
+	getUserInformation();
+
+	// Check if update info should be shown
+	showUpdateInfoIfNeeded();
+
 	// Get the stations and load them to the map
 	await getStations();
 

--- a/scripts/map.js
+++ b/scripts/map.js
@@ -78,7 +78,7 @@ async function initMap() {
 		return;
 	}
 
-	// Check if the user is logged in, if not, prompt to login
+	// Check if the user has a stored access token
 	const accessTokenCookie = getCookie("accessToken");
 	if (accessTokenCookie) {
 		user.accessToken = accessTokenCookie;

--- a/scripts/requests.js
+++ b/scripts/requests.js
@@ -217,10 +217,9 @@ function startWSConnection(force = false) {
 		);
 	};
 
-	ws.onmessage = msg => {
+	ws.onmessage = async msg => {
 		if (typeof msg.data !== "undefined") {
 			let msgObj = JSON.parse(msg.data);
-			console.log(msgObj);
 			if (Object.hasOwn(msgObj, "payload") && msgObj.payload) {
 				if (
 					Object.hasOwn(msgObj.payload, "data") &&
@@ -271,18 +270,17 @@ function startWSConnection(force = false) {
 						// End trip
 						tripEnded = true;
 					} else if (activeTripObj.code === "unauthorized") {
+						// refresh token
+						await tokenRefresh();
+
 						// close current connection
 						ws.send(JSON.stringify({ type: "stop" }));
 						ws = undefined;
-
-						// refresh token
-						tokenRefresh();
 					}
 				} else if (Object.hasOwn(msgObj.payload, "errors") && msgObj.payload.errors) {
-					//alert(msgObj.payload.errors[0].message);
-
+					console.log(msgObj.payload.errors[0].message);
 					// The subscription errored out, restart connection
-					startWSConnection(true);
+					//startWSConnection(true);
 				}
 			}
 		}

--- a/scripts/requests.js
+++ b/scripts/requests.js
@@ -157,7 +157,7 @@ async function makeGetRequest(url, accessToken = null) {
 		accessToken = await tokenRefresh();
 
 		// check if token refresh was successful
-		if (typeof accessToken !== "undefined") {
+		if (accessToken) {
 			// try to make request again
 			return await makeGetRequest(url, accessToken); // be sure to use latest available token
 		}

--- a/scripts/requests.js
+++ b/scripts/requests.js
@@ -13,10 +13,8 @@ async function makePostRequest(url, body, accessToken = null) {
 	const response = await fetch(proxyURL ?? DEFAULT_PROXY, {
 		method: "POST",
 		headers: {
-			"User-Agent": "Gira/3.2.8 (Android 34)",
 			"X-Proxy-URL": url,
 			"Content-Type": "application/json",
-			Priority: "high",
 			"X-Authorization": `Bearer ${accessToken}`,
 		},
 		body: body,
@@ -111,6 +109,44 @@ async function makePostRequest(url, body, accessToken = null) {
 				return;
 			}
 		}
+	} else if (response.status === 403) {
+		// Common API processing error
+		// try for x times to do the request, otherwise just error out
+		if (currentRequestTry < numberOfRequestTries) {
+			// Wait before making next request (reduce error rate)
+			await delay(200);
+			return await makePostRequest(url, body, accessToken);
+		} else {
+			// Warn user about the API error
+			alert("Erro da API (403)");
+
+			// Hide user menu if it is showing
+			hideUserSettings();
+
+			// Hide search place menu if it is showing
+			hidePlaceSearchMenu();
+
+			// Hide bike list menu if it is showing
+			let bikeListMenu = document.getElementById("bikeMenu");
+			if (bikeListMenu) {
+				bikeListMenu.classList.add("smooth-slide-to-bottom");
+				setTimeout(() => bikeListMenu.remove(), 500); // remove element after animation
+				return; // prevent station card from being hidden if there was a bike list menu
+			}
+
+			// Hide station card if it is showing
+			let menu = document.getElementById("stationMenu");
+			if (menu) {
+				menu.classList.add("smooth-slide-to-left");
+				setTimeout(() => menu.remove(), 500); // remove element after animation
+				document.getElementById("zoomControls").classList.add("smooth-slide-down-zoom-controls"); // move zoom controls back down
+			}
+
+			// Reset currentRequestTry
+			currentRequestTry = 0;
+
+			return;
+		}
 	}
 }
 
@@ -124,7 +160,13 @@ async function makeGetRequest(url, accessToken = null) {
 	});
 	if (response.status === 401) {
 		// refresh token
-		tokenRefresh();
+		accessToken = await tokenRefresh();
+
+		// check if token refresh was successful
+		if (typeof accessToken !== "undefined") {
+			// try to make request again
+			return await makeGetRequest(url, accessToken); // be sure to use latest available token
+		}
 	} else if (response.ok) {
 		const responseObject = await response.json();
 		return responseObject;
@@ -137,11 +179,8 @@ async function makeGetRequest(url, accessToken = null) {
 }
 
 function startWSConnection(force = false) {
-	console.log("startWSConnection was called");
 	// if connection already exists, close the old one first
 	if (typeof ws !== "undefined" && ws.readyState === WebSocket.OPEN) {
-		console.log("An open connection already existed");
-
 		if (force === true) {
 			ws.send(JSON.stringify({ type: "stop" }));
 			ws.onopen = ws.onmessage = ws.onerror = ws.onclose = undefined;
@@ -183,7 +222,6 @@ function startWSConnection(force = false) {
 	};
 
 	ws.onmessage = msg => {
-		//console.log(msg);
 		if (typeof msg.data !== "undefined") {
 			let msgObj = JSON.parse(msg.data);
 			if (Object.hasOwn(msgObj, "payload") && msgObj.payload) {
@@ -203,8 +241,7 @@ function startWSConnection(force = false) {
 							if (!finishedTripsList.includes(activeTripObj.code)) finishedTripsList.push(activeTripObj.code);
 
 							// Show the rate trip menu (if trip has not been rated)
-							if (!ratedTripsList.includes(activeTripObj.code) && !document.getElementById("rateTripMenu"))
-								openRateTripMenu(activeTripObj);
+							if (!ratedTripsList.includes(activeTripObj.code) && !tripBeingRated) openRateTripMenu(activeTripObj);
 						} else if (!finishedTripsList.includes(activeTripObj.code)) {
 							// Show the trip overlay if it is not shown already and the user is not on navigation
 							if (!document.querySelector("#tripOverlay") && !navigationActive) {
@@ -256,25 +293,6 @@ function startWSConnection(force = false) {
 
 	ws.onerror = ev => console.log(ev);
 	ws.onclose = ev => {
-		console.log(ev);
 		startWSConnection(); // reconnect automatically if the connection gets closed
 	};
-}
-
-function checkToken(callback) {
-	if (tokenRefreshed === false)
-		return setTimeout(() => checkToken(callback, arguments[1], arguments[2], user.accessToken), 0);
-	else {
-		tokenRefreshSuccessHandler();
-
-		// always use the latest access token
-		return callback(arguments[1], arguments[2], user.accessToken);
-	}
-}
-
-function tokenRefreshSuccessHandler() {
-	console.log("Token has been refreshed!");
-
-	// Hide login menu if it is showing
-	if (document.querySelector(".login-menu")) document.querySelector(".login-menu").remove();
 }

--- a/scripts/requests.js
+++ b/scripts/requests.js
@@ -13,6 +13,7 @@ async function makePostRequest(url, body, accessToken = null) {
 	const response = await fetch(proxyURL ?? DEFAULT_PROXY, {
 		method: "POST",
 		headers: {
+			"User-Agent": "Gira/3.3.5 (Android 34)",
 			"X-Proxy-URL": url,
 			"Content-Type": "application/json",
 			"X-Authorization": `Bearer ${accessToken}`,

--- a/scripts/requests.js
+++ b/scripts/requests.js
@@ -220,6 +220,7 @@ function startWSConnection(force = false) {
 	ws.onmessage = msg => {
 		if (typeof msg.data !== "undefined") {
 			let msgObj = JSON.parse(msg.data);
+			console.log(msgObj);
 			if (Object.hasOwn(msgObj, "payload") && msgObj.payload) {
 				if (
 					Object.hasOwn(msgObj.payload, "data") &&

--- a/scripts/requests.js
+++ b/scripts/requests.js
@@ -43,13 +43,7 @@ async function makePostRequest(url, body, accessToken = null) {
 		return responseObject;
 	} else if (response.status === 400) {
 		const responseObject = await response.json();
-		if (Object.hasOwn(responseObject, "statusDescription")) {
-			if (
-				responseObject.statusDescription.includes("The Email field is required.") ||
-				responseObject.statusDescription.includes("The Password field is required.")
-			)
-				alert("Por favor preencha os campos de email e password!");
-		} else if (responseObject.errors[0].message === "trip_interval_limit") {
+		if (responseObject.errors[0].message === "trip_interval_limit") {
 			alert("Tem de esperar 5 minutos entre viagens.");
 		} else if (responseObject.errors[0].message === "already_active_trip") {
 			alert("Já tem uma viagem a decorrer!");
@@ -186,6 +180,8 @@ function startWSConnection(force = false) {
 			ws.onopen = ws.onmessage = ws.onerror = ws.onclose = undefined;
 		} else return;
 	}
+
+	if (!user.accessToken) return;
 
 	ws = new WebSocket("wss://apigira.emel.pt/graphql", "graphql-ws");
 

--- a/scripts/stations.js
+++ b/scripts/stations.js
@@ -66,22 +66,7 @@ async function getStations() {
 		stationsArray = response.data.getStations;
 		loadStationMarkersFromArray(stationsArray);
 
-		// Hide login menu if it is showing
-		if (document.querySelector(".login-menu")) document.querySelector(".login-menu").remove();
-
-		// Start WebSocket connection
-		startWSConnection();
-
-		// Get all user details
-		getUserInformation();
-
-		// Check if update info should be shown
-		showUpdateInfoIfNeeded();
-
 		return response.data.getStations;
-	} else {
-		// Wait for token refresh
-		checkToken(getStations);
 	}
 }
 

--- a/scripts/tokenRefresh.js
+++ b/scripts/tokenRefresh.js
@@ -57,6 +57,9 @@ async function tokenRefresh() {
 					// Hide login menu if it is showing
 					if (document.querySelector(".login-menu")) document.querySelector(".login-menu").remove();
 
+					// Make sure the ws connection is open
+					startWSConnection();
+
 					// Set that the token has been refreshed successfully
 					tokenRefreshed = true;
 

--- a/scripts/tokenRefresh.js
+++ b/scripts/tokenRefresh.js
@@ -45,24 +45,14 @@ async function tokenRefresh() {
 					refreshTokenExpiryDate.setMonth(refreshTokenExpiryDate.getMonth() + 1);
 
 					// Store refreshToken cookie (stay logged in)
-					document.cookie =
-						"refreshToken=" +
-						user.refreshToken +
-						"; expires=" +
-						refreshTokenExpiryDate.toGMTString() +
-						"; SameSite=strict";
+					createCookie("refreshToken", user.refreshToken, refreshTokenExpiryDate);
 
 					// Set the cookie expiry to 2 minutes after now.
 					const accessTokenExpiryDate = new Date();
 					accessTokenExpiryDate.setMinutes(accessTokenExpiryDate.getMinutes() + 2);
 
 					// Store accessToken cookie (for quick refreshes)
-					document.cookie =
-						"accessToken=" +
-						user.accessToken +
-						"; expires=" +
-						accessTokenExpiryDate.toGMTString() +
-						"; SameSite=strict";
+					createCookie("accessToken", user.accessToken, accessTokenExpiryDate);
 
 					// Hide login menu if it is showing
 					if (document.querySelector(".login-menu")) document.querySelector(".login-menu").remove();

--- a/scripts/tokenRefresh.js
+++ b/scripts/tokenRefresh.js
@@ -12,7 +12,7 @@ async function tokenRefresh() {
 	}
 
 	// Make sure to only refresh the token one at a time
-	if (tokenPromise !== null) return tokenPromise;
+	if (tokenPromise) return tokenPromise;
 
 	// If there are no other calls being processed, create a new promise
 	tokenPromise = new Promise(async (resolve, reject) => {
@@ -21,10 +21,9 @@ async function tokenRefresh() {
 		let currentTry = 0;
 
 		while (currentTry < numberOfTries) {
-			const response = await fetch(proxyURL, {
+			const response = await fetch("https://api-auth.emel.pt/token/refresh", {
 				method: "POST",
 				headers: {
-					"X-Proxy-URL": "https://api-auth.emel.pt/token/refresh",
 					"Content-Type": "application/json",
 				},
 				body: JSON.stringify({

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -133,6 +133,10 @@ function openLoginMenu() {
 	deleteCookie("refreshToken");
 	deleteCookie("accessToken");
 
+	// delete user object
+	user = {};
+	if (ws) ws.close();
+
 	let menu = document.createElement("div");
 	menu.className = "login-menu";
 	menu.id = "loginMenu";

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -28,7 +28,27 @@ async function login(event) {
 			},
 		}),
 	});
+
 	const response = await responseReq.json();
+
+	// Handle login errors
+	if (responseReq.status === 400) {
+		if (Object.hasOwn(response, "statusDescription")) {
+			if (
+				response.statusDescription.includes("The Email field is required.") ||
+				response.statusDescription.includes("The Password field is required.")
+			) {
+				alert("Por favor preencha os campos de email e password!");
+				document.getElementById("loginMenu")?.remove();
+				openLoginMenu();
+				return;
+			}
+		}
+	}
+
+	if (response.error) {
+		if (response.error.message === "Invalid credentials.") alert("Credenciais inválidas.");
+	}
 
 	if (response.data) {
 		// Store the received tokens

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -129,7 +129,6 @@ async function getUserInformation() {
 
 // Open the login menu element and populate it
 function openLoginMenu() {
-	//document.cookie = "version=0.0.0"; // Force show update notes after logout
 	document.cookie = 'refreshToken=None;path="/";expires=Thu, 01 Jan 1970 00:00:01 GMT'; // delete cookie
 	document.cookie = 'accessToken=None;path="/";expires=Thu, 01 Jan 1970 00:00:01 GMT'; // delete cookie
 

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -81,16 +81,14 @@ async function login(event) {
 		refreshTokenExpiryDate.setMonth(refreshTokenExpiryDate.getMonth() + 1);
 
 		// Store refreshToken cookie (stay logged in)
-		document.cookie =
-			"refreshToken=" + user.refreshToken + "; expires=" + refreshTokenExpiryDate.toGMTString() + "; SameSite=strict";
+		createCookie("refreshToken", user.refreshToken, refreshTokenExpiryDate);
 
 		// Set the cookie expiry to 2 minutes after now.
 		const accessTokenExpiryDate = new Date();
 		accessTokenExpiryDate.setMinutes(accessTokenExpiryDate.getMinutes() + 2);
 
 		// Store accessToken cookie (for quick refreshes)
-		document.cookie =
-			"accessToken=" + user.accessToken + "; expires=" + accessTokenExpiryDate.toGMTString() + "; SameSite=strict";
+		createCookie("accessToken", user.accessToken, accessTokenExpiryDate);
 
 		document.getElementById("loginMenu")?.remove();
 		tokenRefreshed = true;
@@ -129,8 +127,11 @@ async function getUserInformation() {
 
 // Open the login menu element and populate it
 function openLoginMenu() {
-	document.cookie = 'refreshToken=None;path="/";expires=Thu, 01 Jan 1970 00:00:01 GMT'; // delete cookie
-	document.cookie = 'accessToken=None;path="/";expires=Thu, 01 Jan 1970 00:00:01 GMT'; // delete cookie
+	console.log("login menu was opened");
+
+	// delete cookies
+	deleteCookie("refreshToken");
+	deleteCookie("accessToken");
 
 	let menu = document.createElement("div");
 	menu.className = "login-menu";
@@ -250,7 +251,7 @@ async function openUserSettings() {
 
 		// Store customProxy cookie
 		proxyURL = document.getElementById("proxyUrlInput").value;
-		document.cookie = "customProxy=" + encodeURI(proxyURL) + "; expires=" + expiryDate.toGMTString();
+		createCookie("customProxy", encodeURI(proxyURL), expiryDate);
 
 		alert("O proxy foi definido.");
 	});
@@ -258,7 +259,8 @@ async function openUserSettings() {
 	document.getElementById("resetProxyButton").addEventListener("click", () => {
 		// Delete customProxy cookie
 		proxyURL = null;
-		document.cookie = 'customProxy=None;path="/";expires=Thu, 01 Jan 1970 00:00:01 GMT';
+		deleteCookie("customProxy");
+
 		// Update input
 		document.getElementById("proxyUrlInput").value = proxyURL;
 
@@ -283,14 +285,18 @@ function openSetProxyPrompt() {
 	createCustomTextPrompt(
 		"Por favor defina um novo proxy.",
 		() => {
+			// Set the cookie expiry to 1 year after today.
+			const expiryDate = new Date();
+			expiryDate.setFullYear(expiryDate.getFullYear() + 1);
+
 			// Store customProxy cookie
-			proxyURL = document.getElementById("customTextPromptInput").value;
-			document.cookie = "customProxy=" + encodeURI(proxyURL);
+			proxyURL = document.getElementById("proxyUrlInput").value;
+			createCookie("customProxy", encodeURI(proxyURL), expiryDate);
 		},
 		() => {
 			// Delete customProxy cookie
 			proxyURL = null;
-			document.cookie = 'customProxy=None;path="/";expires=Thu, 01 Jan 1970 00:00:01 GMT';
+			deleteCookie("customProxy");
 			openLoginMenu();
 		},
 		"Definir",

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -19,7 +19,7 @@ function showUpdateInfoIfNeeded() {
 		const userVersion = getCookie("version");
 		if (userVersion !== currentVersion) {
 			alert(changelogHTML);
-			document.cookie = "version=" + currentVersion + "; expires=" + expiryDate.toGMTString();
+			createCookie("version", currentVersion, expiryDate);
 		}
 	}, 1500);
 }


### PR DESCRIPTION
Melhorei um pouco o sistema dos token refresh:
- retirei as funções de startup que estavam na função getStations
- mudei o número de tentativas de 5 para 3 (número arbitrário, necessário feedback)
- substitui o sistema de uma função de checkToken com um callback para um sistema de promises, assim várias chamadas à tokenRefresh simultâneas respondem da forma correta (é apenas criada uma promise que é devolvida várias vezes até ela estar fulfilled)
- removi alguns console.log sem nenhuma utilidade aparente
- pedido para persistent storage (tentativa de melhorar persistência do login)