### PR TITLE
fix: simplify date parsing in trip history

### DIFF
--- a/scripts/bikes.js
+++ b/scripts/bikes.js
@@ -347,7 +347,7 @@ async function tripTimer(startTime) {
 		// Update timer on trip overlay
 		if (document.querySelector("#tripTime")) {
 			// Calculate elapsed time
-			const elapsedTime = new Date(Date.now() - startTime);
+			const elapsedTime = Date.now() - startTime;
 			for (let element of document.querySelectorAll("#tripTime")) {
 				element.innerHTML = parseMillisecondsIntoTripTime(elapsedTime);
 			}
@@ -379,7 +379,7 @@ async function tripTimer(startTime) {
 
 function openRateTripMenu(tripObj) {
 	// Calculate the trip time
-	const elapsedTime = new Date(Date.parse(tripObj.endDate) - Date.parse(tripObj.startDate));
+	const elapsedTime = Date.parse(tripObj.endDate) - Date.parse(tripObj.startDate);
 	const formattedTime = parseMillisecondsIntoTripTime(elapsedTime, false);
 
 	// Don't rate trips under 90 seconds

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -283,7 +283,8 @@ function openTripHistory() {
 		tripListElement.className = "trip-list-element";
 
 		// Get formatted date. Format: "1 de jan. de 2024"
-		const formattedDate = tripTime.toLocaleDateString("pt", { dateStyle: "medium" });
+		const tripDate = new Date(trip.startDate);
+		const formattedDate = tripDate.toLocaleDateString("pt", { dateStyle: "medium" }).replaceAll(" de ", " ");
 
 		// Get formatted time
 		let tripTime = new Date(Date.parse(trip.endDate) - Date.parse(trip.startDate));

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -282,7 +282,7 @@ function openTripHistory() {
 		const tripListElement = document.createElement("li");
 		tripListElement.className = "trip-list-element";
 
-		// Get formatted date
+		// Get formatted date. Format: "1 de jan. de 2024"
 		const formattedDate = tripTime.toLocaleDateString("pt", { dateStyle: "medium" });
 
 		// Get formatted time

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -283,31 +283,12 @@ function openTripHistory() {
 		tripListElement.className = "trip-list-element";
 
 		// Get formatted date
-		let tripDate = new Date(trip.startDate);
-		let monthNumberToShortForm = [
-			"jan.",
-			"fev.",
-			"mar.",
-			"abr.",
-			"mai.",
-			"jun.",
-			"jul.",
-			"ago.",
-			"set.",
-			"out.",
-			"nov.",
-			"dez.",
-		];
-		const formattedDate = `${tripDate.getDate()} ${
-			monthNumberToShortForm[tripDate.getMonth()]
-		} ${tripDate.getFullYear()}`;
+		const formattedDate = tripTime.toLocaleDateString("pt", { dateStyle: "medium" });
 
 		// Get formatted time
-		let tripTime = new Date(new Date(trip.endDate) - new Date(trip.startDate));
+		let tripTime = new Date(Date.parse(trip.endDate) - Date.parse(trip.startDate));
 		tripTime.setTime(tripTime.getTime() + tripTime.getTimezoneOffset() * 60 * 1000); // Correct because of Daylight Saving Time
-		const hours = tripTime.getHours();
-		const minutes = tripTime.getMinutes();
-		const formattedTime = hours + "h" + minutes.toString().padStart(2, "0") + "m";
+		const formattedTime = tripTime.getHours() + "h" + tripTime.getMinutes().toString().padStart(2, "0") + "m";
 
 		// Get formatted cost
 		let formattedCost = parseFloat(trip.cost).toFixed(2);

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -443,11 +443,11 @@ function updateStatisticsChart() {
 	} else if (period === "lastYear") numberOfDays = 365;
 	else if (period === "total") {
 		// Start from the day the user account was activated
-		let timeFromActivated = Date.now() - new Date(user.dateActivate).getTime();
+		let timeFromActivated = Date.now() - Date.parse(user.dateActivate);
 
 		// Convert the milliseconds to days
-		var days = timeFromActivated / (24 * 1000 * 60 * 60);
-		var absoluteDays = Math.floor(days);
+		const days = timeFromActivated / (24 * 1000 * 60 * 60);
+		const absoluteDays = Math.floor(days);
 
 		numberOfDays = absoluteDays;
 	}
@@ -476,20 +476,22 @@ function updateStatisticsChart() {
 				: `${dayDate.getDate()}/${dayDate.getMonth() + 1}`;
 
 		// Get the trips of the day
-		const dayTrips = user.tripHistory.filter(
-			trip =>
-				new Date(trip.startDate).getDate() === dayDate.getDate() && // Same day
-				new Date(trip.startDate).getMonth() === dayDate.getMonth() && // Same month
-				new Date(trip.startDate).getFullYear() === dayDate.getFullYear() // Same year
-		);
+		const dayTrips = user.tripHistory.filter(trip => {
+			const startDate = new Date(trip.startDate);
+			return (
+				startDate.getDate() === dayDate.getDate() && // Same day
+				startDate.getMonth() === dayDate.getMonth() && // Same month
+				startDate.getFullYear() === dayDate.getFullYear() // Same year
+			);
+		});
 
 		// Get the time (in ms) and distance (in km) ridden for each trip
 		for (trip of dayTrips) {
-			let tripTime = new Date(new Date(trip.endDate) - new Date(trip.startDate));
-			trip.riddenTime = tripTime.getTime();
+			let tripTime = Date.parse(trip.endDate) - Date.parse(trip.startDate);
+			trip.riddenTime = tripTime;
 			// Calculate an estimate for trip distance (assuming an avg speed of 15km/h)
 			const speed = 15 / (3600 * 1000); // convert km/h to km/ms
-			trip.distance = Math.round(tripTime.getTime() * speed * 1000) / 1000; // milliseconds * km in 1 millisecond (and round to 3 decimal places)
+			trip.distance = Math.round(tripTime * speed * 1000) / 1000; // milliseconds * km in 1 millisecond (and round to 3 decimal places)
 		}
 
 		// Create the new object


### PR DESCRIPTION
Neste PR:
- Melhorei a forma como é obtida a data na trip history para usar os métodos built-in. A string fica ligeiramente diferente com a adição da palavra "de" entre cada componente mas se quiseres posso retirar com um replaceAll
- Removi todas as instâncias de new Date() que não eram necessárias já que é uma operação muito cara em termos de processamento e substituí por Date.parse ou por nada em situações em que já era usada como número apenas