### PR TITLE
fix: get subscription name from type

### DIFF
--- a/scripts/extras.js
+++ b/scripts/extras.js
@@ -175,3 +175,7 @@ function getStationsDiff(newStationsArray, oldStationsArray = null) {
 		}
 	}
 }
+
+function toPascalCase(str) {
+	return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/scripts/user.js
+++ b/scripts/user.js
@@ -224,7 +224,7 @@ async function openUserSettings() {
         <div id="subscriptionContainer">
             <div>
                 <i class="bi bi-credit-card" id="cardSVG"></i>
-                <div id="subscriptionName">${userObj.activeUserSubscriptions[0].name}</div>
+                <div id="subscriptionName">Passe ${toPascalCase(userObj.activeUserSubscriptions[0].type)}</div>
                 <div id="subscriptionValidity">Válido até ${subscriptionExpiration.toLocaleDateString("pt")}</div>
             </div>
         </div>


### PR DESCRIPTION
Este PR corrige um pequeno bug que fazia com que o Passe Navegante fosse indistinguível do Passe Mensal. Para isso, utiliza a propriedade "type" to activeUserSubscriptions, em vez do "name". Esta propriedade tem o valor do nome do passe, com a única diferença que vem sempre em minúsculas e diz "navegante" para os passes desse tipo.
![image](https://github.com/afonsosousah/mGira/assets/38259440/cbbe88d8-8632-4e46-a55d-5cc44b4d9672)
