### PR TITLE
fix: always show cycleways layer when hiding place search menu

### DIFF
--- a/scripts/routing.js
+++ b/scripts/routing.js
@@ -735,6 +735,13 @@ function hidePlaceSearchMenu() {
 		.filter(layer => ["placesLayer", "routeLayer"].includes(layer.get("name")))
 		.forEach(layer => map.removeLayer(layer));
 
+	// Show cycleways layer (if hidden)
+	map
+		.getLayers()
+		.getArray()
+		.find(layer => layer.get("name") === "cyclewaysLayer")
+		.setVisible(true);
+
 	// Add back the stations layer
 	loadStationMarkersFromArray(stationsArray);
 


### PR DESCRIPTION
Ao sair do menu de navegação, a layer de cycleways por vezes não aparece, como por exemplo:

1. Clicar no icon de navegação
2. Escrever algo na barra de pesquisa e clicar numa opção
3. Clicar no botão de retroceder

Ao fazer setVisibility(true) na ação de esconder o menu pesquisa/ navegação, garante que a layer de cycleways estará sempre visível no ecrã principal.

Btw, obrigado pela aplicação 🙏